### PR TITLE
SOLAPI Node.js SDK 5.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solapi",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "SOLAPI SDK for Node.js(Server Side Only)",
   "keywords": [
     "solapi",

--- a/src/lib/stringDateTrasnfer.ts
+++ b/src/lib/stringDateTrasnfer.ts
@@ -20,7 +20,10 @@ export default function stringDateTransfer(value: string | Date): Date {
     value = parseISO(value);
     const invalidDateText = 'Invalid Date';
     if (value.toString() === invalidDateText) {
-      throw new InvalidDateError(invalidDateText);
+      throw new InvalidDateError({
+        message: invalidDateText,
+        originalValue: typeof value === 'string' ? value : undefined,
+      });
     }
   }
   return value;

--- a/src/models/requests/messages/requestConfig.ts
+++ b/src/models/requests/messages/requestConfig.ts
@@ -4,7 +4,7 @@ import {Schema} from 'effect';
 // SDK 및 OS 정보
 export const osPlatform = `${process.platform} | ${process.version}`;
 // NOTE: 라이브러리 배포 시 반드시 업데이트해야 합니다.
-export const sdkVersion = 'nodejs/5.5.0';
+export const sdkVersion = 'nodejs/5.5.1';
 
 // Agent 정보 타입
 export type DefaultAgentType = {


### PR DESCRIPTION
## Hot fix
- `stringDateTrasnfer.ts`에서 타입 불일치로 인한 오류를 수정했습니다.