### PR TITLE
ci: beta release-please versioning-strategy prerelease 설정 추가

### DIFF
--- a/release-please-config-beta.json
+++ b/release-please-config-beta.json
@@ -5,6 +5,7 @@
       "release-type": "node",
       "prerelease": true,
       "prerelease-type": "beta",
+      "versioning-strategy": "prerelease",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## 기능 변경사항
- beta release-please 설정에 `versioning-strategy: prerelease`를 추가했습니다.
- 이 설정이 없으면 `6.0.0`으로만 생성되고, `6.0.0-beta.0` 형식이 되지 않습니다.

## 프로젝트 내부 변경사항
- PR #116이 `6.0.0`으로 생성되어 닫고, 설정 수정 후 재생성 예정입니다.

## Test plan
- [ ] 설정 머지 후 beta release-please가 `6.0.0-beta.0` 형식으로 릴리스 PR 생성 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)