### PR TITLE
ci: beta release-please versioning-strategy 및 버전 복원

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solapi",
-  "version": "6.0.0",
+  "version": "5.5.4",
   "description": "SOLAPI SDK for Node.js(Server Side Only)",
   "keywords": [
     "solapi",

--- a/release-please-config-beta.json
+++ b/release-please-config-beta.json
@@ -5,6 +5,7 @@
       "release-type": "node",
       "prerelease": true,
       "prerelease-type": "beta",
+      "versioning-strategy": "prerelease",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## 기능 변경사항
- `release-please-config-beta.json`에 `versioning-strategy: "prerelease"`를 추가했습니다.
- `package.json` version을 `5.5.4`로 복원했습니다. (manifest와 일치)

## 프로젝트 내부 변경사항
release-please가 beta 브랜치에서 config를 읽기 때문에, master에만 반영된 설정이 적용되지 않았습니다.

**근본 원인 (3가지):**
1. `versioning-strategy: "prerelease"` 미설정 → `6.0.0`으로 계산 (`6.0.0-beta.0` 아님)
2. `package.json`이 이미 `6.0.0` → release-please가 "updating from 6.0.0 to 6.0.0" (변경 없음)
3. 결과적으로 릴리스 PR이 실질적 변경 없이 생성됨

**수정 후 예상 동작:**
- manifest `5.5.4` + `feat!` 커밋 → `6.0.0-beta.0` 계산
- `package.json` `5.5.4` → `6.0.0-beta.0`으로 bump
- 정상적인 beta 릴리스 PR 생성

## Test plan
- [ ] 머지 후 Beta Release 워크플로우가 `6.0.0-beta.0` 릴리스 PR 생성 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)