### PR TITLE
ci: release-please versioning 속성명 수정 (beta)

### DIFF
--- a/release-please-config-beta.json
+++ b/release-please-config-beta.json
@@ -5,7 +5,7 @@
       "release-type": "node",
       "prerelease": true,
       "prerelease-type": "beta",
-      "versioning-strategy": "prerelease",
+      "versioning": "prerelease",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## 기능 변경사항
- `release-please-config-beta.json`의 `versioning-strategy`를 `versioning`으로 수정했습니다.

## 프로젝트 내부 변경사항
release-please config schema에 `versioning-strategy` 속성은 존재하지 않습니다.
올바른 속성명은 `versioning`이며, 이 값이 `"prerelease"`여야 `6.0.0-beta.0` 형식이 생성됩니다.

[Schema 참조](https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json)

## Test plan
- [ ] 머지 후 Beta Release 워크플로우가 `6.0.0-beta.0` 릴리스 PR 생성 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)