### PR TITLE
ci: prerelease-type beta.0으로 변경 — 시리얼 넘버링 (beta)

### DIFF
--- a/release-please-config-beta.json
+++ b/release-please-config-beta.json
@@ -4,7 +4,7 @@
     ".": {
       "release-type": "node",
       "prerelease": true,
-      "prerelease-type": "beta",
+      "prerelease-type": "beta.0",
       "versioning": "prerelease",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
## 기능 변경사항
- `prerelease-type`을 `"beta"` → `"beta.0"`으로 변경했습니다.

## 프로젝트 내부 변경사항
release-please의 `bumpPrerelease()` 로직:
- `"beta"` → 첫 버전 `6.0.0-beta` (카운터 없음), 다음 `6.0.0-beta.1`
- `"beta.0"` → 첫 버전 `6.0.0-beta.0`, 다음 `6.0.0-beta.1`, `beta.2`, ...

시리얼 넘버가 0부터 시작하여 semantic version은 고정된 채 beta 번호만 증가합니다.

## Test plan
- [ ] 릴리스 PR이 `6.0.0-beta.0` 형식으로 생성되는지 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)