### PR TITLE
ci: biome formatter에서 package.json 제외

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,6 +17,7 @@
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,
+    "includes": ["**", "!package.json"],
     "indentStyle": "space",
     "indentWidth": 2,
     "lineEnding": "lf",


### PR DESCRIPTION
## 기능 변경사항
- biome formatter의 includes에서 `package.json`을 제외했습니다.

## 프로젝트 내부 변경사항
release-please가 `package.json`을 업데이트할 때 `"files"` 배열을 multi-line으로 포맷합니다.
biome는 single-line을 기대하므로 `lint:ci`(biome check)에서 포맷 에러가 발생합니다.

release-please가 매 릴리스마다 `package.json`을 수정하므로, formatter 대상에서 제외하는 것이 올바른 해결책입니다.

## Test plan
- [ ] release-please PR의 CI lint가 통과하는지 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)