### PR TITLE
chore(ci): harden supply-chain workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/scripts/wait-for-workflow.sh
+++ b/.github/scripts/wait-for-workflow.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+workflow_file="${1:?workflow file is required}"
+branch_name="${2:?branch name is required}"
+commit_sha="${3:?commit sha is required}"
+poll_seconds="${4:-10}"
+max_attempts="${5:-60}"
+
+echo "Waiting for ${workflow_file} on ${branch_name}@${commit_sha}"
+
+for attempt in $(seq 1 "${max_attempts}"); do
+  run_json="$(
+    gh run list \
+      --workflow "${workflow_file}" \
+      --branch "${branch_name}" \
+      --commit "${commit_sha}" \
+      --event push \
+      --limit 20 \
+      --json databaseId,headSha,status,conclusion \
+      --jq 'map(select(.headSha == "'"${commit_sha}"'")) | first'
+  )"
+
+  if [[ -z "${run_json}" || "${run_json}" == "null" ]]; then
+    echo "Attempt ${attempt}/${max_attempts}: workflow run not found yet."
+    sleep "${poll_seconds}"
+    continue
+  fi
+
+  run_id="$(jq -r '.databaseId' <<<"${run_json}")"
+  run_status="$(jq -r '.status' <<<"${run_json}")"
+  run_conclusion="$(jq -r '.conclusion // empty' <<<"${run_json}")"
+
+  echo "Attempt ${attempt}/${max_attempts}: run=${run_id} status=${run_status} conclusion=${run_conclusion:-pending}"
+
+  if [[ "${run_status}" != "completed" ]]; then
+    sleep "${poll_seconds}"
+    continue
+  fi
+
+  if [[ "${run_conclusion}" == "success" ]]; then
+    echo "${workflow_file} succeeded for ${commit_sha}"
+    exit 0
+  fi
+
+  echo "${workflow_file} concluded with ${run_conclusion} for ${commit_sha}"
+  exit 1
+done
+
+echo "Timed out while waiting for ${workflow_file} on ${commit_sha}"
+exit 1

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -5,10 +5,7 @@ on:
     types: [ published ]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -18,27 +15,31 @@ jobs:
   build-docs:
     if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v5
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: 18
-        cache: pnpm
-        cache-dependency-path: pnpm-lock.yaml
-    - name: Setup Pages
-      uses: actions/configure-pages@v6
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-    - name: Build docs
-      run: pnpm run docs
-    - name: Upload Pages artifact
-      uses: actions/upload-pages-artifact@v4
-      with:
-        path: docs
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          run_install: false
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 18
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build docs
+        run: pnpm run docs
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: docs
 
   deploy:
     if: ${{ !github.event.release.prerelease }}
@@ -47,7 +48,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build-docs
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
     branches: [master, beta]
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -18,23 +17,26 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  ci:
-    name: CI (Node ${{ matrix.node-version }})
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18, 20, 22]
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -44,8 +46,77 @@ jobs:
       - name: Lint
         run: pnpm lint:ci
 
+  test-matrix:
+    name: Test Matrix (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Test (unit only)
         run: pnpm test:ci
+
+  test:
+    name: Test
+    if: ${{ always() }}
+    needs: test-matrix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify matrix result
+        run: |
+          if [ "${{ needs.test-matrix.result }}" != "success" ]; then
+            echo "::error::At least one Node compatibility test failed."
+            exit 1
+          fi
+
+  build:
+    name: Build
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 18
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm tsup

--- a/.github/workflows/release-please-beta.yml
+++ b/.github/workflows/release-please-beta.yml
@@ -1,18 +1,11 @@
 name: Beta Release
 
 on:
-  workflow_run:
-    workflows: ["CI"]
+  push:
     branches: [beta]
-    types: [completed]
+  workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  actions: write
-  statuses: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: release-please-beta
@@ -22,12 +15,35 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  wait-for-ci:
+    name: Wait for CI
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Wait for CI workflow to succeed
+        env:
+          BRANCH: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/wait-for-workflow.sh ci.yml "$BRANCH" "$COMMIT_SHA"
+
   release-please:
     name: Release Please (Beta)
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+    needs: wait-for-ci
+    if: ${{ always() && github.ref_name == 'beta' && (github.event_name != 'push' || needs.wait-for-ci.result == 'success') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -35,7 +51,7 @@ jobs:
     steps:
       - name: Release Please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: beta
@@ -54,7 +70,7 @@ jobs:
 
       - name: Get PR head SHA
         id: pr-sha
-        if: ${{ !steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -65,8 +81,11 @@ jobs:
   test-release-pr:
     name: Test (Beta Release PR)
     needs: release-please
-    if: ${{ !needs.release-please.outputs.release_created && needs.release-please.outputs.pr_head_sha != '' }}
+    if: ${{ needs.release-please.result == 'success' && needs.release-please.outputs.release_created != 'true' && needs.release-please.outputs.pr_head_sha != '' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - name: Set pending status
         env:
@@ -75,23 +94,24 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh api "repos/$REPO/statuses/$SHA" \
-            -f state=pending -f context="Test (Beta)" -f description="Running tests..." \
+            -f state=pending -f context="Test" -f description="Running tests..." \
           || echo "::warning::Failed to set pending status on $SHA"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.release-please.outputs.pr_head_sha }}
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 18
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -111,7 +131,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh api "repos/$REPO/statuses/$SHA" \
-            -f state=success -f context="Test (Beta)" -f description="Tests passed" \
+            -f state=success -f context="Test" -f description="Tests passed" \
           || echo "::warning::Failed to report success status on $SHA"
 
       - name: Report failure
@@ -123,14 +143,17 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh api "repos/$REPO/statuses/$SHA" \
-            -f state=failure -f context="Test (Beta)" -f description="Tests failed" \
+            -f state=failure -f context="Test" -f description="Tests failed" \
           || echo "::warning::Failed to report failure status on $SHA"
 
   lint-release-pr:
     name: Lint (Beta Release PR)
     needs: release-please
-    if: ${{ !needs.release-please.outputs.release_created && needs.release-please.outputs.pr_head_sha != '' }}
+    if: ${{ needs.release-please.result == 'success' && needs.release-please.outputs.release_created != 'true' && needs.release-please.outputs.pr_head_sha != '' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - name: Set pending status
         env:
@@ -139,23 +162,24 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh api "repos/$REPO/statuses/$SHA" \
-            -f state=pending -f context="Lint (Beta)" -f description="Running lint..." \
+            -f state=pending -f context="Lint" -f description="Running lint..." \
           || echo "::warning::Failed to set pending status on $SHA"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.release-please.outputs.pr_head_sha }}
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 18
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -172,7 +196,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh api "repos/$REPO/statuses/$SHA" \
-            -f state=success -f context="Lint (Beta)" -f description="Lint passed" \
+            -f state=success -f context="Lint" -f description="Lint passed" \
           || echo "::warning::Failed to report success status on $SHA"
 
       - name: Report failure
@@ -184,29 +208,36 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh api "repos/$REPO/statuses/$SHA" \
-            -f state=failure -f context="Lint (Beta)" -f description="Lint failed" \
+            -f state=failure -f context="Lint" -f description="Lint failed" \
           || echo "::warning::Failed to report failure status on $SHA"
 
   publish:
     name: Publish to npm (Beta)
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.result == 'success' && needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
+    environment: release
+    env:
+      HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 18
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
@@ -215,7 +246,12 @@ jobs:
       - name: Build
         run: pnpm tsup
 
-      - name: Publish with provenance (beta)
+      - name: Publish beta with trusted publishing
+        if: ${{ env.HAS_NPM_TOKEN != 'true' }}
+        run: npm publish --provenance --access public --tag beta
+
+      - name: Publish with provenance token fallback (beta)
+        if: ${{ env.HAS_NPM_TOKEN == 'true' }}
         run: npm publish --provenance --access public --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,18 +1,11 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["CI"]
+  push:
     branches: [master]
-    types: [completed]
+  workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  actions: write
-  statuses: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: release-please-master
@@ -22,12 +15,35 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  wait-for-ci:
+    name: Wait for CI
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Wait for CI workflow to succeed
+        env:
+          BRANCH: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/wait-for-workflow.sh ci.yml "$BRANCH" "$COMMIT_SHA"
+
   release-please:
     name: Release Please
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push'
+    needs: wait-for-ci
+    if: ${{ always() && github.ref_name == 'master' && (github.event_name != 'push' || needs.wait-for-ci.result == 'success') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -35,7 +51,7 @@ jobs:
     steps:
       - name: Release Please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,7 +67,7 @@ jobs:
 
       - name: Get PR head SHA
         id: pr-sha
-        if: ${{ !steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.release_created != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -62,8 +78,11 @@ jobs:
   test-release-pr:
     name: Test (Release PR)
     needs: release-please
-    if: ${{ !needs.release-please.outputs.release_created && needs.release-please.outputs.pr_head_sha != '' }}
+    if: ${{ needs.release-please.result == 'success' && needs.release-please.outputs.release_created != 'true' && needs.release-please.outputs.pr_head_sha != '' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - name: Set pending status
         continue-on-error: true
@@ -76,19 +95,20 @@ jobs:
             -f state=pending -f context="Test" -f description="Running tests..."
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.release-please.outputs.pr_head_sha }}
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 18
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -122,8 +142,11 @@ jobs:
   lint-release-pr:
     name: Lint (Release PR)
     needs: release-please
-    if: ${{ !needs.release-please.outputs.release_created && needs.release-please.outputs.pr_head_sha != '' }}
+    if: ${{ needs.release-please.result == 'success' && needs.release-please.outputs.release_created != 'true' && needs.release-please.outputs.pr_head_sha != '' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - name: Set pending status
         continue-on-error: true
@@ -136,19 +159,20 @@ jobs:
             -f state=pending -f context="Lint" -f description="Running lint..."
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.release-please.outputs.pr_head_sha }}
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 18
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -179,23 +203,30 @@ jobs:
   publish:
     name: Publish to npm
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.result == 'success' && needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
+    environment: release
+    env:
+      HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 18
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
@@ -204,7 +235,12 @@ jobs:
       - name: Build
         run: pnpm tsup
 
-      - name: Publish with provenance
+      - name: Publish with trusted publishing
+        if: ${{ env.HAS_NPM_TOKEN != 'true' }}
+        run: npm publish --provenance --access public
+
+      - name: Publish with provenance token fallback
+        if: ${{ env.HAS_NPM_TOKEN == 'true' }}
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,58 @@
+name: GitHub Actions Security
+
+on:
+  push:
+    branches: [master, beta]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/scripts/**"
+      - ".github/dependabot.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  pull_request:
+    branches: [master, beta]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/scripts/**"
+      - ".github/dependabot.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Audit GitHub Actions
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
## Summary
- replace the release workflow chain with a CI gate that preserves the current release-please flow on trusted branches
- pin GitHub Actions by full SHA, add workflow security checks, and add Dependabot updates for npm and GitHub Actions
- prepare release workflows for a protected release environment and trusted publishing fallback

## Verification
- pnpm lint:ci
- pnpm test:ci
- YAML parsing for all workflow files
- bash -n .github/scripts/wait-for-workflow.sh
- validated wait-for-workflow.sh against recent upstream master and beta CI runs