### PR TITLE
[codex] fix(ci): use release-please component branch names

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,7 +72,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          SHA=$(gh pr list --repo "$REPO" --head release-please--branches--master --state open --json headRefOid --jq '.[0].headRefOid // empty')
+          SHA=$(gh pr list --repo "$REPO" --head release-please--branches--master--components--solapi --state open --json headRefOid --jq '.[0].headRefOid // empty')
           echo "sha=${SHA:-}" >> "$GITHUB_OUTPUT"
 
   test-release-pr:


### PR DESCRIPTION
## What changed
- update the release-please PR SHA lookup to use the actual component-scoped branch name for `master`

## Why
The release workflow currently queries `release-please--branches--master`, but release-please opens the PR from `release-please--branches--master--components--solapi`. That causes `Get PR head SHA` to return empty, so the release PR validation jobs skip and the required `Lint`/`Test` contexts are never posted.

## Impact
- restores release PR validation without changing the current release-please publishing flow
- keeps the supply-chain hardening work intact

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "ok"'`
- `git diff --check`