### PR TITLE
fix(ci): use Node 24 for npm Trusted Publishers OIDC support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,7 +249,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 18
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
@@ -261,7 +261,7 @@ jobs:
       - name: Publish
         env:
           NPM_TAG: ${{ github.ref_name == 'beta' && 'beta' || 'latest' }}
-        run: npm publish --tag "$NPM_TAG"
+        run: npm publish --provenance --access public --tag "$NPM_TAG"
 
       - name: Report publish failure
         if: failure()


### PR DESCRIPTION
## Summary

npm publish E404 수정: Node 18 (npm 10.8.2)은 Trusted Publishers OIDC를 지원하지 않음.
beta PR (#145)과 동일 변경의 master 적용.

## Changes

publish job만 변경:
- `node-version: 18` → `node-version: 24`
- `npm publish --tag` → `npm publish --provenance --access public --tag`

🤖 Generated with [Claude Code](https://claude.com/claude-code)