### PR TITLE
refactor: remove dead code and align with effect best practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Schema.String.pipe(
 | File | Purpose |
 |------|---------|
 | `defaultFetcher.ts` | HTTP client — Effect.gen, retry 3x exponential backoff, Match |
-| `effectErrorHandler.ts` | `runSafePromise`, `runSafeSync`, `unwrapCause` |
+| `effectErrorHandler.ts` | `runSafePromise`, `unwrapCause` |
 | `authenticator.ts` | HMAC-SHA256 auth header |
 | `stringifyQuery.ts` | URL query string builder (array handling) |
 | `fileToBase64.ts` | File/URL → Base64 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ pnpm docs             # Generate TypeDoc documentation
 - 에러: `Data.TaggedError` + environment-aware `toString()`
 - 비동기: `Effect.gen` + `Effect.tryPromise`
 - 검증: Effect Schema (`Schema.filter`, `Schema.transform`)
-- Promise 변환: `runSafePromise()` / `runSafeSync()`
+- Promise 변환: `runSafePromise()`
 
 ### Path Aliases
 ```

--- a/src/lib/defaultFetcher.ts
+++ b/src/lib/defaultFetcher.ts
@@ -14,12 +14,30 @@ type DefaultRequest = {
   method: string;
 };
 
+const ERROR_MESSAGE_PREVIEW_LENGTH = 200;
+const RETRYABLE_ERROR_KEYWORDS = [
+  'aborted',
+  'refused',
+  'reset',
+  'econn',
+] as const;
+
 class RetryableError extends Data.TaggedError('RetryableError')<{
   readonly error?: unknown;
 }> {}
 
 const toMessage = (e: unknown): string =>
   e instanceof Error ? e.message : String(e);
+
+const isRetryableNetworkError = (error: Error): boolean => {
+  const cause = error.cause;
+  const causeCode =
+    cause && typeof cause === 'object' && 'code' in cause
+      ? String(cause.code)
+      : '';
+  const message = `${error.message} ${causeCode}`.toLowerCase();
+  return RETRYABLE_ERROR_KEYWORDS.some(keyword => message.includes(keyword));
+};
 
 const makeParseError = (res: Response, message: string) =>
   new DefaultError({
@@ -62,7 +80,9 @@ const handleClientErrorResponse = (res: Response) =>
     Effect.flatMap(text => {
       const genericError = new ClientError({
         errorCode: `HTTP_${res.status}`,
-        errorMessage: text.substring(0, 200) || 'Client error occurred',
+        errorMessage:
+          text.substring(0, ERROR_MESSAGE_PREVIEW_LENGTH) ||
+          'Client error occurred',
         httpStatus: res.status,
         url: res.url,
       });
@@ -148,7 +168,8 @@ const handleServerErrorResponse = (res: Response) =>
 
       const genericError = makeError(
         `HTTP_${res.status}`,
-        text.substring(0, 200) || 'Server error occurred',
+        text.substring(0, ERROR_MESSAGE_PREVIEW_LENGTH) ||
+          'Server error occurred',
       );
 
       return parseServerErrorBody(text, genericError, makeError);
@@ -191,18 +212,7 @@ export function defaultFetcherEffect<T, R>(
         }),
       catch: (error: unknown) => {
         if (error instanceof Error) {
-          const cause = error.cause;
-          const causeCode =
-            cause && typeof cause === 'object' && 'code' in cause
-              ? String(cause.code)
-              : '';
-          const message = (error.message + ' ' + causeCode).toLowerCase();
-          const isRetryable =
-            message.includes('aborted') ||
-            message.includes('refused') ||
-            message.includes('reset') ||
-            message.includes('econn');
-          if (isRetryable) {
+          if (isRetryableNetworkError(error)) {
             return new RetryableError({error});
           }
           return new NetworkError({

--- a/src/lib/effectErrorHandler.ts
+++ b/src/lib/effectErrorHandler.ts
@@ -76,16 +76,6 @@ const unwrapCause = (cause: Cause.Cause<unknown>): unknown => {
   return new UnhandledExitError({message});
 };
 
-export const runSafeSync = <E, A>(effect: Effect.Effect<A, E>): A => {
-  const exit = Effect.runSyncExit(effect);
-  return Exit.match(exit, {
-    onFailure: cause => {
-      throw unwrapCause(cause);
-    },
-    onSuccess: value => value,
-  });
-};
-
 export const runSafePromise = <E, A>(
   effect: Effect.Effect<A, E>,
 ): Promise<A> => {

--- a/src/lib/schemaUtils.ts
+++ b/src/lib/schemaUtils.ts
@@ -1,4 +1,4 @@
-import {Schema} from 'effect';
+import {ParseResult, Schema} from 'effect';
 import * as Effect from 'effect/Effect';
 import {BadRequestError, InvalidDateError} from '../errors/defaultError';
 import stringDateTransfer, {formatWithTransfer} from './stringDateTransfer';
@@ -6,6 +6,8 @@ import stringDateTransfer, {formatWithTransfer} from './stringDateTransfer';
 /**
  * Schema 디코딩 + BadRequestError 변환을 결합한 Effect 헬퍼.
  * 서비스 레이어에서 반복되는 검증 패턴을 통일합니다.
+ * Effect 공식 ParseResult 포맷터(TreeFormatter/ArrayFormatter)로
+ * 에러 경로를 구조화하여 디버깅 가능성을 높입니다.
  */
 export const decodeWithBadRequest = <A, I>(
   schema: Schema.Schema<A, I>,
@@ -15,7 +17,11 @@ export const decodeWithBadRequest = <A, I>(
     Schema.decodeUnknown(schema)(data),
     error =>
       new BadRequestError({
-        message: error.message,
+        message: ParseResult.TreeFormatter.formatErrorSync(error),
+        validationErrors: ParseResult.ArrayFormatter.formatErrorSync(error).map(
+          issue =>
+            `${issue.path.length > 0 ? issue.path.join('.') : '(root)'}: ${issue.message}`,
+        ),
       }),
   );
 

--- a/src/models/base/kakao/kakaoAlimtalkTemplate.ts
+++ b/src/models/base/kakao/kakaoAlimtalkTemplate.ts
@@ -1,7 +1,7 @@
+import {type InvalidDateError} from '@errors/defaultError';
 import {safeDateTransfer} from '@lib/schemaUtils';
 import {Schema} from 'effect';
 import * as Effect from 'effect/Effect';
-import {type InvalidDateError} from '@/errors/defaultError';
 import {kakaoAlimtalkTemplateQuickReplySchema} from './kakaoAlimtalkTemplateQuickReply';
 import {kakaoButtonSchema} from './kakaoButton';
 import {type KakaoChannelCategory} from './kakaoChannel';

--- a/src/models/base/kakao/kakaoChannel.ts
+++ b/src/models/base/kakao/kakaoChannel.ts
@@ -1,7 +1,7 @@
+import {type InvalidDateError} from '@errors/defaultError';
 import {safeDateTransfer} from '@lib/schemaUtils';
 import {Schema} from 'effect';
 import * as Effect from 'effect/Effect';
-import {type InvalidDateError} from '@/errors/defaultError';
 
 /**
  * @description 카카오 채널 카테고리 타입

--- a/src/models/base/messages/message.ts
+++ b/src/models/base/messages/message.ts
@@ -1,8 +1,8 @@
 import {baseKakaoOptionSchema} from '@models/base/kakao/kakaoOption';
 import {naverOptionSchema} from '@models/base/naver/naverOption';
 import {rcsOptionSchema} from '@models/base/rcs/rcsOption';
+import {voiceOptionSchema} from '@models/requests/voice/voiceOption';
 import {Schema} from 'effect';
-import {voiceOptionSchema} from '@/models/requests/voice/voiceOption';
 
 export const messageTypeSchema = Schema.Literal(
   'SMS',

--- a/src/models/base/naver/naverOption.ts
+++ b/src/models/base/naver/naverOption.ts
@@ -1,6 +1,5 @@
 import {Schema} from 'effect';
 
-// 네이버 스마트 알림 naverOptions 버튼 스키마
 const naverOptionButtonSchema = Schema.Struct({
   buttonName: Schema.String,
   buttonType: Schema.String,
@@ -10,7 +9,6 @@ const naverOptionButtonSchema = Schema.Struct({
   linkIos: Schema.optional(Schema.String),
 });
 
-// naverOptions 최상위 스키마
 export const naverOptionSchema = Schema.Struct({
   talkId: Schema.String,
   templateId: Schema.String,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,7 +1,5 @@
-// Base Models - Kakao BMS
 export * from './base/kakao/bms';
 
-// Base Models - Kakao
 export {
   decodeKakaoAlimtalkTemplate,
   type KakaoAlimtalkTemplate,
@@ -67,12 +65,10 @@ export {
   messageSchema,
   messageTypeSchema,
 } from './base/messages/message';
-// Base Models - Naver
 export {
   type NaverOptionSchema,
   naverOptionSchema,
 } from './base/naver/naverOption';
-// Base Models - RCS
 export {
   type RcsButton,
   type RcsButtonSchema,
@@ -88,8 +84,5 @@ export {
   rcsOptionSchema,
 } from './base/rcs/rcsOption';
 
-// Requests
 export * from './requests/index';
-
-// Responses
 export * from './responses/index';

--- a/src/models/requests/messages/getMessagesRequest.ts
+++ b/src/models/requests/messages/getMessagesRequest.ts
@@ -20,7 +20,6 @@ const baseGetMessagesRequestSchema = Schema.Struct({
   endDate: Schema.optional(Schema.Union(Schema.String, Schema.DateFromSelf)),
 });
 
-// dateType은 startDate 또는 endDate가 함께 제공될 때만 유효
 export const getMessagesRequestSchema = baseGetMessagesRequestSchema.pipe(
   Schema.filter(data => {
     const hasDate = data.startDate != null || data.endDate != null;
@@ -59,7 +58,6 @@ export type GetMessagesRequest =
   | GetMessagesRequestWithStartDate
   | GetMessagesRequestWithEndDate;
 
-// 스키마 디코딩 결과 타입 (런타임 검증 후 내부에서 사용)
 type GetMessagesRequestDecoded = Schema.Schema.Type<
   typeof getMessagesRequestSchema
 >;

--- a/src/services/messages/groupService.ts
+++ b/src/services/messages/groupService.ts
@@ -16,6 +16,10 @@ import {
 } from '@models/requests/messages/groupMessageRequest';
 import {osPlatform, sdkVersion} from '@models/requests/messages/requestConfig';
 import {
+  type RequestSendMessagesSchema,
+  requestSendMessageSchema,
+} from '@models/requests/messages/sendMessage';
+import {
   AddMessageResponse,
   GetGroupsResponse,
   GetMessagesResponse,
@@ -23,10 +27,6 @@ import {
   RemoveGroupMessagesResponse,
 } from '@models/responses/messageResponses';
 import * as Effect from 'effect/Effect';
-import {
-  type RequestSendMessagesSchema,
-  requestSendMessageSchema,
-} from '@/models/requests/messages/sendMessage';
 import DefaultService from '../defaultService';
 
 /**

--- a/src/types/commonTypes.ts
+++ b/src/types/commonTypes.ts
@@ -1,7 +1,5 @@
 import {Schema} from 'effect';
 
-// --- Count & Charge Types ---
-
 export const countSchema = Schema.Struct({
   total: Schema.Number,
   sentTotal: Schema.Number,
@@ -62,8 +60,6 @@ export type MessageTypeRecord = Schema.Schema.Type<
   typeof messageTypeRecordSchema
 >;
 
-// --- App & Log ---
-
 export const appSchema = Schema.Struct({
   profit: messageTypeRecordSchema,
   appId: Schema.NullishOr(Schema.String),
@@ -74,8 +70,6 @@ export const logSchema = Schema.Array(
   Schema.Record({key: Schema.String, value: Schema.Unknown}),
 );
 export type Log = Schema.Schema.Type<typeof logSchema>;
-
-// --- Group ---
 
 export const groupIdSchema = Schema.String;
 export type GroupId = Schema.Schema.Type<typeof groupIdSchema>;
@@ -101,12 +95,8 @@ export const groupSchema = Schema.Struct({
 });
 export type Group = Schema.Schema.Type<typeof groupSchema>;
 
-// --- Handle Key ---
-
 export const handleKeySchema = Schema.String;
 export type HandleKey = Schema.Schema.Type<typeof handleKeySchema>;
-
-// --- Black (080 수신거부) ---
 
 export const blackSchema = Schema.Struct({
   handleKey: handleKeySchema,
@@ -117,8 +107,6 @@ export const blackSchema = Schema.Struct({
   dateUpdated: Schema.String,
 });
 export type Black = Schema.Schema.Type<typeof blackSchema>;
-
-// --- Block Group ---
 
 export const blockGroupSchema = Schema.Struct({
   blockGroupId: Schema.String,
@@ -131,8 +119,6 @@ export const blockGroupSchema = Schema.Struct({
   dateUpdated: Schema.String,
 });
 export type BlockGroup = Schema.Schema.Type<typeof blockGroupSchema>;
-
-// --- Block Number ---
 
 export const blockNumberSchema = Schema.Struct({
   blockNumberId: Schema.String,

--- a/test/lib/effectErrorHandler.test.ts
+++ b/test/lib/effectErrorHandler.test.ts
@@ -6,73 +6,7 @@ import {
   UnexpectedDefectError,
   UnhandledExitError,
 } from '../../src/errors/defaultError';
-import {runSafePromise, runSafeSync} from '../../src/lib/effectErrorHandler';
-
-describe('runSafeSync', () => {
-  it('should return value on success', () => {
-    const result = runSafeSync(Effect.succeed(42));
-    expect(result).toBe(42);
-  });
-
-  it('should throw original TaggedError on expected failure', () => {
-    const effect = Effect.fail(new BadRequestError({message: '잘못된 요청'}));
-    expect(() => runSafeSync(effect)).toThrow('잘못된 요청');
-    try {
-      runSafeSync(effect);
-    } catch (e) {
-      expect((e as BadRequestError)._tag).toBe('BadRequestError');
-    }
-  });
-
-  it('should throw UnexpectedDefectError for non-Error defects', () => {
-    const effect = Effect.die('unexpected string defect');
-    try {
-      runSafeSync(effect);
-    } catch (e) {
-      expect((e as UnexpectedDefectError)._tag).toBe('UnexpectedDefectError');
-    }
-  });
-
-  it('should handle defect with non-string _tag as generic object', () => {
-    expect.assertions(2);
-    const effect = Effect.die({_tag: 42, message: 'numeric tag'});
-    try {
-      runSafeSync(effect);
-    } catch (e) {
-      const err = e as UnexpectedDefectError;
-      expect(err._tag).toBe('UnexpectedDefectError');
-      expect(err.message).not.toContain('Tagged Error');
-    }
-  });
-
-  it('should handle tagged defect without message property', () => {
-    expect.assertions(2);
-    const effect = Effect.die({_tag: 'CustomTag'});
-    try {
-      runSafeSync(effect);
-    } catch (e) {
-      const err = e as UnexpectedDefectError;
-      expect(err._tag).toBe('UnexpectedDefectError');
-      expect(err.message).toContain('CustomTag');
-    }
-  });
-
-  it('should throw original Error for Error defects', () => {
-    const originalError = new TypeError('type mismatch');
-    const effect = Effect.die(originalError);
-    expect(() => runSafeSync(effect)).toThrow(originalError);
-  });
-
-  it('should throw UnhandledExitError for interrupted effects', () => {
-    const effect = Effect.interrupt;
-    try {
-      runSafeSync(effect);
-    } catch (e) {
-      expect((e as UnhandledExitError)._tag).toBe('UnhandledExitError');
-      expect(e).toBeInstanceOf(Error);
-    }
-  });
-});
+import {runSafePromise} from '../../src/lib/effectErrorHandler';
 
 describe('runSafePromise', () => {
   it('should resolve on success', async () => {
@@ -91,12 +25,47 @@ describe('runSafePromise', () => {
     }
   });
 
+  it('should reject with BadRequestError preserving original fields', async () => {
+    const effect = Effect.fail(new BadRequestError({message: '잘못된 요청'}));
+    try {
+      await runSafePromise(effect);
+    } catch (e) {
+      const err = e as BadRequestError;
+      expect(err._tag).toBe('BadRequestError');
+      expect(err.message).toBe('잘못된 요청');
+    }
+  });
+
   it('should reject with UnexpectedDefectError for non-Error defects', async () => {
     const effect = Effect.die({weird: 'object'});
     try {
       await runSafePromise(effect);
     } catch (e) {
       expect((e as UnexpectedDefectError)._tag).toBe('UnexpectedDefectError');
+    }
+  });
+
+  it('should handle defect with non-string _tag as generic object', async () => {
+    expect.assertions(2);
+    const effect = Effect.die({_tag: 42, message: 'numeric tag'});
+    try {
+      await runSafePromise(effect);
+    } catch (e) {
+      const err = e as UnexpectedDefectError;
+      expect(err._tag).toBe('UnexpectedDefectError');
+      expect(err.message).not.toContain('Tagged Error');
+    }
+  });
+
+  it('should handle tagged defect without message property', async () => {
+    expect.assertions(2);
+    const effect = Effect.die({_tag: 'CustomTag'});
+    try {
+      await runSafePromise(effect);
+    } catch (e) {
+      const err = e as UnexpectedDefectError;
+      expect(err._tag).toBe('UnexpectedDefectError');
+      expect(err.message).toContain('CustomTag');
     }
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,8 @@
       "@models/requests/messages/*": ["src/models/requests/messages/*"],
       "@lib/*": ["src/lib/*"],
       "@internal-types/*": ["src/types/*"],
-      "@services/*": ["src/services/*"]
+      "@services/*": ["src/services/*"],
+      "@errors/*": ["src/errors/*"]
     },
 
     /* Additional Type Checking */


### PR DESCRIPTION
## Summary

`worktree-unified-prancing-moonbeam` 브랜치에서 진행한 refactor만 beta에 반영합니다. 기존 PR #149는 upstream master/beta 격차로 인한 workflow 파일 충돌이 있어 close하고, upstream/beta 기반으로 refactor 커밋(`da2b980`)만 cherry-pick했습니다. workflow/CI 관련 파일은 이 PR에서 다루지 않으며, upstream master에 이미 통합된 상태를 유지합니다.

15 파일 / +71 -120.

## Changes

- **Dead code**: `src/lib/effectErrorHandler.ts`의 production 미사용 `runSafeSync` 제거 + 테스트를 `runSafePromise`로 이관
- **Path aliases**: src/ 내 4개 파일의 `@/` 혼용을 `@errors`/`@models`로 통일, `tsconfig.json`에 `@errors/*` 매핑 추가 (tsup.config.ts/CLAUDE.md와 정합)
- **Clarity**: `src/lib/defaultFetcher.ts`의 inline 재시도 감지 로직을 `isRetryableNetworkError` 헬퍼 + `RETRYABLE_ERROR_KEYWORDS` / `ERROR_MESSAGE_PREVIEW_LENGTH` 상수로 분리
- **Effect best practice**: `src/lib/schemaUtils.ts`의 `decodeWithBadRequest`가 Effect 공식 `ParseResult.TreeFormatter` + `ArrayFormatter`를 사용해 구조화된 `validationErrors`(경로 포함)를 `BadRequestError`에 주입
- **Style**: `commonTypes.ts`, `models/index.ts`, `naverOption.ts`, `getMessagesRequest.ts`의 WHAT/섹션 분할 주석 제거
- **Docs**: `CLAUDE.md`, `AGENTS.md`에서 `runSafeSync` 언급 제거

## Verification (upstream/beta 기반)

- [x] `pnpm lint` — Biome clean
- [x] `pnpm test` — 277/277 passed
- [x] `pnpm build` — tsup + .d.ts 정상
- [x] `npx effect-language-service diagnostics` — 0 errors / 0 warnings / 0 messages (88 파일)
- [x] `rg "runSafeSync" src` — 0건
- [x] `rg "from '@/" src` — 0건

## Test plan

- [ ] upstream CI 통과 확인
- [ ] Public API 시그니처 무변경 확인 (`runSafeSync`는 src/index.ts에서 re-export되지 않은 internal 심볼)

🤖 Generated with [Claude Code](https://claude.com/claude-code)