### PR TITLE
docs(examples): drop stale sendOne note from send_sms comment

### DIFF
--- a/examples/javascript/common/src/sms/send_sms.js
+++ b/examples/javascript/common/src/sms/send_sms.js
@@ -8,7 +8,7 @@ const messageService = new SolapiMessageService(
   'ENTER_YOUR_API_SECRET',
 );
 
-// 단일 발송 예제, send 메소드로도 동일하게 사용가능
+// 단일 발송 예제
 messageService
   .send({
     to: '수신번호',


### PR DESCRIPTION
## Summary

`examples/javascript/common/src/sms/send_sms.js`의 stale 주석 한 줄을 정리합니다.

- sendOne/sendOneFuture 메서드는 이미 `send`로 통합되어 있어, \"send 메소드로도 동일하게 사용가능\" 안내 문구(line 11)는 의미가 사라졌습니다.
- 해당 문구만 제거하여 현재 API 사양(`send`만 존재)과 일치시킵니다.

## Changes

- `examples/javascript/common/src/sms/send_sms.js` (1 line)
  - `// 단일 발송 예제, send 메소드로도 동일하게 사용가능` → `// 단일 발송 예제`

## Test plan

- [x] `rg "sendOne|sendOneFuture|send 메소드로도" examples` → 0건
- [x] 타입/소스 변경 없음 (주석 한 줄만 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)