### PR TITLE
fix(docs): restore GitHub Pages deployment for v6.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Lint
         run: pnpm lint:ci
 
+      - name: Typecheck
+        run: pnpm typecheck
+
   test-matrix:
     name: Test Matrix (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,3 +276,22 @@ jobs:
 
           ---
           > **WARNING**: npm publish failed. Package was NOT published to npm." || true
+
+  trigger-docs:
+    name: Trigger Docs Build
+    needs: [release-please, publish]
+    if: >-
+      needs.release-please.result == 'success'
+      && needs.release-please.outputs.release_created == 'true'
+      && needs.publish.result == 'success'
+      && github.ref_name == 'master'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch build-docs workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+          REPO: ${{ github.repository }}
+        run: gh workflow run build-docs.yaml --repo "$REPO" --ref "$TAG"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "docs": "typedoc --entryPointStrategy expand ./src",
     "lint": "biome check --write",
     "lint:ci": "biome check",
+    "typecheck": "tsc --noEmit",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:ci": "vitest run --exclude '**/*.e2e.test.ts'",

--- a/src/lib/schemaUtils.ts
+++ b/src/lib/schemaUtils.ts
@@ -45,7 +45,7 @@ export const safeDateTransfer = (
                 message: error instanceof Error ? error.message : String(error),
               }),
       })
-    : Effect.void;
+    : Effect.succeed<Date | undefined>(undefined);
 
 /**
  * formatWithTransfer를 Effect로 감싸 InvalidDateError가 Defect가 되지 않도록 합니다.

--- a/test/lib/bms-test-utils.ts
+++ b/test/lib/bms-test-utils.ts
@@ -2,10 +2,10 @@ import path from 'path';
 import type {
   BmsCarouselCommerceItemSchema,
   BmsCarouselFeedItemSchema,
+  BmsChatBubbleType,
   BmsMainWideItemSchema,
   BmsSubWideItemSchema,
 } from '@/models/base/kakao/bms';
-import type {BmsChatBubbleType} from '@/models/base/kakao/kakaoOption';
 import type {FileType} from '@/models/requests/messages/groupMessageRequest';
 import type StorageService from '@/services/storage/storageService';
 

--- a/test/models/base/kakao/bms/bmsConstraints.test.ts
+++ b/test/models/base/kakao/bms/bmsConstraints.test.ts
@@ -27,14 +27,14 @@ describe('validateCouponDescription', () => {
   });
 
   it.each([
-    ['TEXT', 12, true],
-    ['IMAGE', 12, true],
-    ['COMMERCE', 12, true],
-    ['CAROUSEL_FEED', 12, true],
-    ['CAROUSEL_COMMERCE', 12, true],
-    ['PREMIUM_VIDEO', 12, true],
-    ['WIDE', 18, true],
-    ['WIDE_ITEM_LIST', 18, true],
+    ['TEXT', 12],
+    ['IMAGE', 12],
+    ['COMMERCE', 12],
+    ['CAROUSEL_FEED', 12],
+    ['CAROUSEL_COMMERCE', 12],
+    ['PREMIUM_VIDEO', 12],
+    ['WIDE', 18],
+    ['WIDE_ITEM_LIST', 18],
   ] as const)('should accept coupon description at exact max length for %s (%d chars)', (chatBubbleType, maxLen) => {
     const result = validateCouponDescription({
       chatBubbleType,

--- a/test/models/requests/messages/sendMessage.test.ts
+++ b/test/models/requests/messages/sendMessage.test.ts
@@ -597,6 +597,8 @@ describe('sendRequestConfigSchema', () => {
     });
     const encoded = Schema.encodeSync(sendRequestConfigSchema)(decoded);
 
-    expect(encoded.scheduledDate!.getTime()).toBe(originalDate.getTime());
+    expect(new Date(encoded.scheduledDate!).getTime()).toBe(
+      originalDate.getTime(),
+    );
   });
 });


### PR DESCRIPTION
## Summary

v6.0.0 릴리즈 이후 **GitHub Pages API Reference 문서 배포가 중단**된 이슈를 두 개의 독립 원인으로 나눠 수정한다.

1. `pnpm run docs` (typedoc)가 `tsconfig`의 `include: ["src/**/*", "test/**/*"]` 기준으로 전체 TS 컴파일을 수행하다 **4개 타입 에러로 실패** — CI가 Biome/Vitest/tsup(esbuild 계열)만 돌려 타입 검증 공백이 있었음
2. release-please가 기본 `GITHUB_TOKEN`으로 생성한 GitHub Release의 `release: [published]` 이벤트는 GitHub Actions 정책상 **다음 워크플로를 트리거하지 않음** — v6.0.0 릴리즈 이후 `build-docs.yaml`이 자동 실행되지 않은 근본 원인

## Changes

**타입 에러 수정 (Phase A)**
- `src/lib/schemaUtils.ts:48` — `Effect.void`(`Effect<void, never>`) → `Effect.succeed<Date | undefined>(undefined)`
- `test/lib/bms-test-utils.ts:8` — `BmsChatBubbleType`를 정식 re-export 위치(`@/models/base/kakao/bms`)에서 import
- `test/models/base/kakao/bms/bmsConstraints.test.ts:29-44` — `it.each` 튜플의 미사용 3번째 원소(`true`) 제거로 콜백 시그니처와 일치화
- `test/models/requests/messages/sendMessage.test.ts:600` — `Schema.encodeSync` 결과의 `scheduledDate`가 `string | Date`이므로 `new Date(...)` 정규화 후 `.getTime()` 호출

**회귀 방지 게이트 (Phase B)**
- `package.json`에 `"typecheck": "tsc --noEmit"` 스크립트 신설
- `.github/workflows/ci.yml`의 `lint` 잡에 `Typecheck` step 추가

**릴리즈 → 문서 빌드 체인 복구 (Phase C)**
- `.github/workflows/release.yml`에 `trigger-docs` 잡 추가
  - `needs: [release-please, publish]`
  - gating: `release_created == 'true'` + `publish.result == 'success'` + `github.ref_name == 'master'`
  - `permissions: actions: write` (최소 권한)
  - `gh workflow run build-docs.yaml --repo "$REPO" --ref "$TAG"` — `workflow_dispatch`는 `GITHUB_TOKEN`으로도 기동 가능하므로 명시적 디스패치 경로로 정책 제약 우회

build-docs.yaml의 기존 `release: [published]` 트리거와 `workflow_dispatch`는 **그대로 유지**해 수동 재빌드 경로 및 향후 PAT 전환 여지를 보존.

## Test plan

로컬 검증 (모두 green):
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm test:ci` — 374/374 passed
- [x] `pnpm run docs` — exit 0, `docs/index.html` 생성 (warning only)
- [x] `pnpm build` — lint + tsup 성공
- [x] YAML 파싱 유효성 확인

CI/CD 검증 (이 PR 자체):
- [ ] `CI`의 신설 `Typecheck` step 통과
- [ ] `CI`의 `test-matrix`(Node 18/20/22) + `build` 통과
- [ ] `GitHub Actions Security` 통과

배포 후 검증 (머지 이후 수동):
1. 본 PR이 `master`에 머지된 뒤:
   ```bash
   gh workflow run build-docs.yaml --repo solapi/solapi-nodejs --ref solapi-v6.0.0
   ```
   → v6.0.0 태그 커밋 기준으로 문서 빌드, GitHub Pages에 즉시 반영
2. 차후 정식 릴리즈에서 `Release` 워크플로의 `trigger-docs` 잡이 `build-docs`를 자동 디스패치하는지 확인

## Related PRs (merged into fork master)

- Palbahngmiyine/solapi-nodejs#17 — Phase A + B
- Palbahngmiyine/solapi-nodejs#18 — Phase C

🤖 Generated with [Claude Code](https://claude.com/claude-code)